### PR TITLE
[Week6] 로그인 및 Jwt 과제 제출

### DIFF
--- a/app/src/main/java/com/codesoom/assignment/application/AuthenticationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/AuthenticationService.java
@@ -1,0 +1,42 @@
+package com.codesoom.assignment.application;
+
+import com.codesoom.assignment.domain.User;
+import com.codesoom.assignment.domain.UserRepository;
+import com.codesoom.assignment.dto.UserLoginData;
+import com.codesoom.assignment.errors.PasswordNotCorrectException;
+import com.codesoom.assignment.errors.UserNotFoundException;
+import com.codesoom.assignment.utils.JwtUtil;
+import org.springframework.stereotype.Service;
+
+/**
+ * 인증 관련 비즈니스 로직을 처리합니다.
+ */
+@Service
+public class AuthenticationService {
+
+    private JwtUtil jwtUtil;
+
+    private UserRepository userRepository;
+
+    public AuthenticationService(JwtUtil jwtUtil, UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 사용자 로그인 정보로 로그인하고
+     * 토큰을 발행해 리턴합니다.
+     * @param userLoginData 로그인 하기 위한 사용자 정보
+     * @return 발행 한 토큰
+     */
+    public String login(UserLoginData userLoginData) {
+        User foundUser = userRepository.findByEmail(userLoginData.getEmail())
+                                       .orElseThrow(() -> new UserNotFoundException(userLoginData.getEmail()));
+
+        if (!foundUser.authenticate(userLoginData.getPassword())) {
+            throw new PasswordNotCorrectException();
+        }
+
+        return jwtUtil.encode(userLoginData.getEmail());
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/application/AuthenticationService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/AuthenticationService.java
@@ -24,8 +24,7 @@ public class AuthenticationService {
     }
 
     /**
-     * 사용자 로그인 정보로 로그인하고
-     * 토큰을 발행해 리턴합니다.
+     * 사용자 로그인 정보로 로그인하고 토큰을 발행해 리턴합니다.
      * @param userLoginData 로그인 하기 위한 사용자 정보
      * @return 발행 한 토큰
      */
@@ -38,5 +37,14 @@ public class AuthenticationService {
         }
 
         return jwtUtil.encode(userLoginData.getEmail());
+    }
+
+    /**
+     * 엑세스 토큰을 디코드해서 사용자 이메일을 리턴합니다.
+     * @param accessToken 엑세스 토큰
+     * @return 사용자 이메일
+     */
+    public String parseToken(String accessToken) {
+        return jwtUtil.decode(accessToken).get("userEmail", String.class);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/controllers/ControllerErrorAdvice.java
+++ b/app/src/main/java/com/codesoom/assignment/controllers/ControllerErrorAdvice.java
@@ -1,6 +1,7 @@
 package com.codesoom.assignment.controllers;
 
 import com.codesoom.assignment.dto.ErrorResponse;
+import com.codesoom.assignment.errors.PasswordNotCorrectException;
 import com.codesoom.assignment.errors.ProductNotFoundException;
 import com.codesoom.assignment.errors.UserEmailDuplicationException;
 import com.codesoom.assignment.errors.UserNotFoundException;
@@ -10,24 +11,50 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
+/**
+ * 컨트롤러 관련 예외처리를 담당합니다.
+ */
 @ResponseBody
 @ControllerAdvice
 public class ControllerErrorAdvice {
+
+    /**
+     * 상품을 찾지 못 했을때 에러 메세지를 리턴합니다.
+     * @return 에러 메세지
+     */
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(ProductNotFoundException.class)
     public ErrorResponse handleProductNotFound() {
         return new ErrorResponse("Product not found");
     }
 
+    /**
+     * 사용자를 찾지 못 했을때 에러 메세지를 리턴합니다.
+     * @return 에러 메세지
+     */
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(UserNotFoundException.class)
     public ErrorResponse handleUserNotFound() {
         return new ErrorResponse("User not found");
     }
 
+    /**
+     * 사용자 이메일이 중복일때 에러 메세지를 리턴합니다.
+     * @return 에러 메세지
+     */
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(UserEmailDuplicationException.class)
     public ErrorResponse handleUserEmailIsAlreadyExisted() {
         return new ErrorResponse("User's email address is already existed");
+    }
+
+    /**
+     * 사용자 비밀번호가 틀렸을때 에러 메세지를 리턴합니다.
+     * @return 에러 메세지
+     */
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler(PasswordNotCorrectException.class)
+    public ErrorResponse handlePasswordNotCorrect() {
+        return new ErrorResponse("Password Not Correct");
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/controllers/ControllerErrorAdvice.java
+++ b/app/src/main/java/com/codesoom/assignment/controllers/ControllerErrorAdvice.java
@@ -1,6 +1,7 @@
 package com.codesoom.assignment.controllers;
 
 import com.codesoom.assignment.dto.ErrorResponse;
+import com.codesoom.assignment.errors.InvalidTokenException;
 import com.codesoom.assignment.errors.PasswordNotCorrectException;
 import com.codesoom.assignment.errors.ProductNotFoundException;
 import com.codesoom.assignment.errors.UserEmailDuplicationException;
@@ -19,8 +20,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 public class ControllerErrorAdvice {
 
     /**
-     * 상품을 찾지 못 했을때 에러 메세지를 리턴합니다.
-     * @return 에러 메세지
+     * 상품을 찾지 못 했을때 에러 응답을 리턴합니다.
+     * @return 에러 응답
      */
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(ProductNotFoundException.class)
@@ -29,8 +30,8 @@ public class ControllerErrorAdvice {
     }
 
     /**
-     * 사용자를 찾지 못 했을때 에러 메세지를 리턴합니다.
-     * @return 에러 메세지
+     * 사용자를 찾지 못 했을때 에러 응답을 리턴합니다.
+     * @return 에러 응답
      */
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler(UserNotFoundException.class)
@@ -39,8 +40,8 @@ public class ControllerErrorAdvice {
     }
 
     /**
-     * 사용자 이메일이 중복일때 에러 메세지를 리턴합니다.
-     * @return 에러 메세지
+     * 사용자 이메일이 중복일때 에러 응답을 리턴합니다.
+     * @return 에러 응답
      */
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(UserEmailDuplicationException.class)
@@ -49,12 +50,22 @@ public class ControllerErrorAdvice {
     }
 
     /**
-     * 사용자 비밀번호가 틀렸을때 에러 메세지를 리턴합니다.
-     * @return 에러 메세지
+     * 사용자 비밀번호가 틀렸을때 에러 응답을 리턴합니다.
+     * @return 에러 응답
      */
-    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(PasswordNotCorrectException.class)
     public ErrorResponse handlePasswordNotCorrect() {
         return new ErrorResponse("Password Not Correct");
+    }
+
+    /**
+     * 토큰이 유효하지 않을때 에러 응답을 리턴합니다.
+     * @return 에러 응답
+     */
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(InvalidTokenException.class)
+    public ErrorResponse handleInvalidToken() {
+        return new ErrorResponse("Invalid token");
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/controllers/ProductController.java
+++ b/app/src/main/java/com/codesoom/assignment/controllers/ProductController.java
@@ -1,5 +1,6 @@
 package com.codesoom.assignment.controllers;
 
+import com.codesoom.assignment.application.AuthenticationService;
 import com.codesoom.assignment.application.ProductService;
 import com.codesoom.assignment.domain.Product;
 import com.codesoom.assignment.dto.ProductData;
@@ -9,47 +10,93 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.List;
 
+/**
+ * 상품 관련 http 요청 처리를 담당합니다.
+ */
 @RestController
 @RequestMapping("/products")
 @CrossOrigin
 public class ProductController {
     private final ProductService productService;
 
-    public ProductController(ProductService productService) {
+    private final AuthenticationService authenticationService;
+
+    public ProductController(ProductService productService, AuthenticationService authenticationService) {
         this.productService = productService;
+        this.authenticationService = authenticationService;
     }
 
+    /**
+     * 상품 목록 요청을 받아 조회하고 상품 목록을 리턴합니다.
+     * @return 상품 목록
+     */
     @GetMapping
     public List<Product> list() {
         return productService.getProducts();
     }
 
+    /**
+     * 상품 상세정보 요청을 받아 조회하고 상품을 리턴합니다.
+     * @param id 요청 한 상품 id
+     * @return 상품
+     */
     @GetMapping("{id}")
     public Product detail(@PathVariable Long id) {
         return productService.getProduct(id);
     }
 
+    /**
+     * 권한을 확인하고 새 상품 등록 요청을 받아 등록하고 리턴합니다.
+     * @param authorization 권한 확인을 위한 토큰
+     * @param productData 새로 등록할 상품 내용
+     * @return 새로 등록 한 상품
+     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public Product create(
+            @RequestHeader("Authorization") String authorization,
             @RequestBody @Valid ProductData productData
     ) {
+        String accessToken = getAccessToken(authorization);
+        authenticationService.parseToken(accessToken);
         return productService.createProduct(productData);
     }
 
+    /**
+     * 권한을 확인하고 상품 수정 요청을 받아 수정하고 리턴합니다.
+     * @param authorization 권한 확인을 위한 토큰
+     * @param id 수정 할 상품 id
+     * @param productData 수정 할 상품 정보
+     * @return 상품
+     */
     @PatchMapping("{id}")
     public Product update(
+            @RequestHeader("Authorization") String authorization,
             @PathVariable Long id,
             @RequestBody @Valid ProductData productData
     ) {
+        String accessToken = getAccessToken(authorization);
+        authenticationService.parseToken(accessToken);
         return productService.updateProduct(id, productData);
     }
 
+    /**
+     * 권한을 확인하고 상품 삭제 요청을 받아 삭제합니다.
+     * @param authorization 권한 확인을 위한 토큰
+     * @param id 삭제 할 상품 id
+     */
     @DeleteMapping("{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void destroy(
+            @RequestHeader("Authorization") String authorization,
             @PathVariable Long id
     ) {
+        String accessToken = getAccessToken(authorization);
+        authenticationService.parseToken(accessToken);
         productService.deleteProduct(id);
+    }
+
+    private String getAccessToken(String authorization) {
+        return authorization.substring("Bearer ".length());
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/controllers/SessionController.java
+++ b/app/src/main/java/com/codesoom/assignment/controllers/SessionController.java
@@ -1,0 +1,41 @@
+package com.codesoom.assignment.controllers;
+
+import com.codesoom.assignment.application.AuthenticationService;
+import com.codesoom.assignment.dto.SessionResponseData;
+import com.codesoom.assignment.dto.UserLoginData;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+/**
+ * 로그인 세션 관련 http 요청 처리를 담당합니다.
+ */
+@RestController
+@RequestMapping("/session")
+public class SessionController {
+
+    private final AuthenticationService authenticationService;
+
+    public SessionController(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    /**
+     * 로그인 요청을 받아 엑세스 토큰을 리턴합니다.
+     * @param userLoginData 로그인 하기 위한 사용자 정보
+     * @return 엑세스 토큰
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SessionResponseData login(@RequestBody @Valid UserLoginData userLoginData) {
+        String accessToken = authenticationService.login(userLoginData);
+        return SessionResponseData.builder()
+                                  .accessToken(accessToken)
+                                  .build();
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/dto/SessionResponseData.java
+++ b/app/src/main/java/com/codesoom/assignment/dto/SessionResponseData.java
@@ -1,0 +1,14 @@
+package com.codesoom.assignment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 엑세스 토큰 응답객체 입니다.
+ */
+@Getter
+@Builder
+public class SessionResponseData {
+
+    private String accessToken;
+}

--- a/app/src/main/java/com/codesoom/assignment/dto/SessionResponseData.java
+++ b/app/src/main/java/com/codesoom/assignment/dto/SessionResponseData.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
- * 엑세스 토큰 응답객체 입니다.
+ * 엑세스 토큰 응답객체.
  */
 @Getter
 @Builder

--- a/app/src/main/java/com/codesoom/assignment/dto/UserLoginData.java
+++ b/app/src/main/java/com/codesoom/assignment/dto/UserLoginData.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 /**
- * 사용자 로그인 Dto
+ * 사용자 로그인 정보.
  */
 @Getter
 @Builder

--- a/app/src/main/java/com/codesoom/assignment/dto/UserLoginData.java
+++ b/app/src/main/java/com/codesoom/assignment/dto/UserLoginData.java
@@ -1,0 +1,31 @@
+package com.codesoom.assignment.dto;
+
+import com.github.dozermapper.core.Mapping;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+/**
+ * 사용자 로그인 Dto
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserLoginData {
+
+    @NotBlank
+    @Email
+    @Mapping("email")
+    private String email;
+
+    @NotBlank
+    @Size(min = 4, max = 20)
+    @Mapping("password")
+    private String password;
+}

--- a/app/src/main/java/com/codesoom/assignment/errors/InvalidTokenException.java
+++ b/app/src/main/java/com/codesoom/assignment/errors/InvalidTokenException.java
@@ -1,0 +1,11 @@
+package com.codesoom.assignment.errors;
+
+/**
+ * 토큰이 유효하지 않은 경우에 던집니다.
+ */
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException(String token) {
+        super("Invalid Token: " + token);
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/errors/PasswordNotCorrectException.java
+++ b/app/src/main/java/com/codesoom/assignment/errors/PasswordNotCorrectException.java
@@ -1,0 +1,10 @@
+package com.codesoom.assignment.errors;
+
+/**
+ * 패스워드가 틀린 경우에 던집니다.
+ */
+public class PasswordNotCorrectException extends RuntimeException {
+    public PasswordNotCorrectException() {
+        super("Password not correct");
+    }
+}

--- a/app/src/main/java/com/codesoom/assignment/errors/UserNotFoundException.java
+++ b/app/src/main/java/com/codesoom/assignment/errors/UserNotFoundException.java
@@ -1,7 +1,14 @@
 package com.codesoom.assignment.errors;
 
+/**
+ * 사용자를 찾을 수 없는 경우에 던집니다.
+ */
 public class UserNotFoundException extends RuntimeException {
     public UserNotFoundException(Long id) {
         super("User not found: " + id);
+    }
+
+    public UserNotFoundException(String email) {
+        super("User not found: " + email);
     }
 }

--- a/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
+++ b/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
@@ -18,10 +18,10 @@ import java.security.Key;
 public class JwtUtil {
 
     private final String USER_EMAIL = "userEmail";
-    private final Key key;
+    private final Key secretKey;
 
-    public JwtUtil(@Value("${jwt.secret}") String secret) {
-        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    public JwtUtil(@Value("${jwt.secret}") String secretKey) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
     /**
@@ -32,7 +32,7 @@ public class JwtUtil {
     public String encode(String userEmail) {
         return Jwts.builder()
                    .claim(USER_EMAIL, userEmail)
-                   .signWith(key)
+                   .signWith(secretKey)
                    .compact();
     }
 
@@ -47,7 +47,7 @@ public class JwtUtil {
         }
         try {
             return Jwts.parserBuilder()
-                       .setSigningKey(key)
+                       .setSigningKey(secretKey)
                        .build()
                        .parseClaimsJws(token)
                        .getBody();

--- a/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
+++ b/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
@@ -1,0 +1,58 @@
+package com.codesoom.assignment.utils;
+
+import com.codesoom.assignment.errors.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+
+/**
+ * Jwt 토큰 관련 운영을 담당합니다.
+ */
+@Component
+public class JwtUtil {
+
+    private final String USER_EMAIL = "userEmail";
+    private final Key key;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    /**
+     * 사용자 메일과 키로 Jwt 토큰을 발행해 리턴합니다.
+     * @param userEmail 사용자 메일
+     * @return Jwt 토큰
+     */
+    public String encode(String userEmail) {
+        return Jwts.builder()
+                   .claim(USER_EMAIL, userEmail)
+                   .signWith(key)
+                   .compact();
+    }
+
+    /**
+     * 토큰을 풀고 Jwt 클레임을 리턴합니다.
+     * @param token 풀 토큰
+     * @return Jwt 클레임
+     */
+    public Claims decode(String token) {
+        if (token == null || StringUtils.isBlank(token)) {
+            throw new InvalidTokenException(token);
+        }
+        try {
+            return Jwts.parserBuilder()
+                       .setSigningKey(key)
+                       .build()
+                       .parseClaimsJws(token)
+                       .getBody();
+        } catch (SignatureException e) {
+            throw new InvalidTokenException(token);
+        }
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/application/AuthenticationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/AuthenticationServiceTest.java
@@ -1,0 +1,120 @@
+package com.codesoom.assignment.application;
+
+import com.codesoom.assignment.domain.User;
+import com.codesoom.assignment.domain.UserRepository;
+import com.codesoom.assignment.dto.UserLoginData;
+import com.codesoom.assignment.errors.PasswordNotCorrectException;
+import com.codesoom.assignment.errors.UserNotFoundException;
+import com.codesoom.assignment.utils.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AuthenticationServiceTest {
+
+    private static final String SECRET = "12345678901234567890123456789012";
+    private static final String EXISTED_EMAIL = "example@login.com";
+    private static final String NOT_EXISTED_EMAIL = "not-existed@login.com";
+    private static final String CORRECT_PASSWORD = "password";
+    private static final String INCORRECT_PASSWORD = "incorrect";
+    private static final String ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJleGFtcGxlQ" +
+                                               "GxvZ2luLmNvbSJ9.VC6A_h3VehY_zvmxNGtgdwCc6zeFRBcdKSkj2rNB93Y";
+
+    private AuthenticationService authenticationService;
+
+    private UserRepository userRepository = mock(UserRepository.class);
+
+    private User user;
+
+    private UserLoginData userLoginData;
+
+    @BeforeEach
+    void setUp() {
+        JwtUtil jwtUtil = new JwtUtil(SECRET);
+        authenticationService = new AuthenticationService(jwtUtil, userRepository);
+
+        user = User.builder()
+                   .email(EXISTED_EMAIL)
+                   .password(CORRECT_PASSWORD)
+                   .build();
+    }
+
+    @Nested
+    @DisplayName("login 메소드는")
+    class Describe_login {
+
+        @Nested
+        @DisplayName("유효한 사용자 로그인 정보가 주어지면")
+        class Context_with_valid_userLoginData {
+
+            @BeforeEach
+            void prepareUserLoginData() {
+                userLoginData = UserLoginData.builder()
+                                             .email(EXISTED_EMAIL)
+                                             .password(CORRECT_PASSWORD)
+                                             .build();
+
+                given(userRepository.findByEmail(EXISTED_EMAIL)).willReturn(Optional.of(user));
+            }
+
+            @Test
+            @DisplayName("Access Token을 리턴한다")
+            void it_returns_access_token() {
+                String accessToken = authenticationService.login(userLoginData);
+                assertThat(accessToken).isEqualTo(ACCESS_TOKEN);
+                verify(userRepository).findByEmail(EXISTED_EMAIL);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Email이 주어지면")
+        class Context_with_not_existed_email {
+
+            @BeforeEach
+            void prepareNotExistedEmail() {
+                userLoginData = UserLoginData.builder()
+                                             .email(NOT_EXISTED_EMAIL)
+                                             .password(CORRECT_PASSWORD)
+                                             .build();
+
+                given(userRepository.findByEmail(NOT_EXISTED_EMAIL)).willThrow(new UserNotFoundException(NOT_EXISTED_EMAIL));
+            }
+
+            @Test
+            @DisplayName("UserNotFoundException 예외를 던진다")
+            void it_returns_userNotFoundException() {
+                assertThatThrownBy(() -> authenticationService.login(userLoginData)).isInstanceOf(UserNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 틀린 password가 주어지면")
+        class Context_with_incorrect_password {
+
+            @BeforeEach
+            void prepareIncorrectPassword() {
+                userLoginData = UserLoginData.builder()
+                                             .email(EXISTED_EMAIL)
+                                             .password(INCORRECT_PASSWORD)
+                                             .build();
+
+                given(userRepository.findByEmail(EXISTED_EMAIL)).willReturn(Optional.of(user));
+            }
+
+            @Test
+            @DisplayName("PasswordNotCorrectException 예외를 던진다")
+            void it_returns_passwordNotCorrectException() {
+                assertThatThrownBy(() -> authenticationService.login(userLoginData)).isInstanceOf(PasswordNotCorrectException.class);
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/application/AuthenticationServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/AuthenticationServiceTest.java
@@ -67,7 +67,7 @@ class AuthenticationServiceTest {
             }
 
             @Test
-            @DisplayName("Access Token을 리턴한다")
+            @DisplayName("이메일로 사용자를 찾고 Access Token을 리턴한다")
             void it_returns_access_token() {
                 String accessToken = authenticationService.login(userLoginData);
                 assertThat(accessToken).isEqualTo(ACCESS_TOKEN);

--- a/app/src/test/java/com/codesoom/assignment/application/ProductServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/ProductServiceTest.java
@@ -9,6 +9,8 @@ import com.github.dozermapper.core.Mapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,7 +40,7 @@ class ProductServiceTest {
                 .price(5000)
                 .build();
 
-        given(productRepository.findAll()).willReturn(List.of(product));
+        given(productRepository.findAll()).willReturn(Arrays.asList(product));
 
         given(productRepository.findById(1L)).willReturn(Optional.of(product));
 
@@ -55,7 +57,7 @@ class ProductServiceTest {
 
     @Test
     void getProductsWithNoProduct() {
-        given(productRepository.findAll()).willReturn(List.of());
+        given(productRepository.findAll()).willReturn(Collections.emptyList());
 
         assertThat(productService.getProducts()).isEmpty();
     }

--- a/app/src/test/java/com/codesoom/assignment/controllers/ProductControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/ProductControllerTest.java
@@ -1,10 +1,15 @@
 package com.codesoom.assignment.controllers;
 
+import com.codesoom.assignment.application.AuthenticationService;
 import com.codesoom.assignment.application.ProductService;
 import com.codesoom.assignment.domain.Product;
 import com.codesoom.assignment.dto.ProductData;
+import com.codesoom.assignment.errors.InvalidTokenException;
 import com.codesoom.assignment.errors.ProductNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -23,11 +28,22 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
+
+    private final String BEARER_TOKEN = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJzZWRpbkBzZWRpbi5jb20ifQ.8VOB4g3s0uBkx3pNQnzI-LPg5DgdZs7yTizzbpIAvx0";
+    private final String INVALID_BEARER_TOKEN = "invalid";
+    private final String UPDATE_PREFIX = "업데이트";
+    private final String PRODUCT_NAME = "쥐돌이";
+    private final String PRODUCT_MAKER = "냥이월드";
+    private final String USER_EMAIL = "sedin@sedin.com";
+    private final int PRODUCT_PRICE = 5000;
+    private final Long EXISTED_ID = 1L;
+    private final Long NOT_EXISTED_ID = 1000L;
 
     @Autowired
     private MockMvc mockMvc;
@@ -35,153 +51,369 @@ class ProductControllerTest {
     @MockBean
     private ProductService productService;
 
+    @MockBean
+    private AuthenticationService authenticationService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Product product;
+
     @BeforeEach
-    void setUp() {
-        Product product = Product.builder()
-                .id(1L)
-                .name("쥐돌이")
-                .maker("냥이월드")
-                .price(5000)
-                .build();
-        given(productService.getProducts()).willReturn(Arrays.asList(product));
+    void prepare() {
+        product = Product.builder()
+                         .id(EXISTED_ID)
+                         .name(PRODUCT_NAME)
+                         .maker(PRODUCT_MAKER)
+                         .price(PRODUCT_PRICE)
+                         .build();
 
-        given(productService.getProduct(1L)).willReturn(product);
-
-        given(productService.getProduct(1000L))
-                .willThrow(new ProductNotFoundException(1000L));
-
-        given(productService.createProduct(any(ProductData.class)))
-                .willReturn(product);
-
-        given(productService.updateProduct(eq(1L), any(ProductData.class)))
-                .will(invocation -> {
-                    Long id = invocation.getArgument(0);
-                    ProductData productData = invocation.getArgument(1);
-                    return Product.builder()
-                            .id(id)
-                            .name(productData.getName())
-                            .maker(productData.getMaker())
-                            .price(productData.getPrice())
-                            .build();
-                });
-
-        given(productService.updateProduct(eq(1000L), any(ProductData.class)))
-                .willThrow(new ProductNotFoundException(1000L));
-
-        given(productService.deleteProduct(1000L))
-                .willThrow(new ProductNotFoundException(1000L));
+        given(authenticationService.parseToken(any(String.class))).willReturn(USER_EMAIL);
     }
 
-    @Test
-    void list() throws Exception {
-        mockMvc.perform(
-                get("/products")
-                        .accept(MediaType.APPLICATION_JSON_UTF8)
-        )
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("쥐돌이")));
+    @Nested
+    @DisplayName("GET /products 는")
+    class Describe_list {
+
+        @Nested
+        @DisplayName("프로덕트가 있으면")
+        class Context_with_product {
+
+            @BeforeEach
+            void prepareProduct() {
+                given(productService.getProducts()).willReturn(Arrays.asList(product));
+            }
+
+            @Test
+            @DisplayName("HttpStatus 200 OK를 응답한다")
+            void it_returns_ok() throws Exception {
+                mockMvc.perform(get("/products")
+                               .accept(MediaType.APPLICATION_JSON_UTF8))
+                       .andExpect(status().isOk())
+                       .andExpect(content().string(containsString(PRODUCT_NAME)));
+
+                verify(productService).getProducts();
+            }
+        }
     }
 
-    @Test
-    void detailWithExistedProduct() throws Exception {
-        mockMvc.perform(
-                get("/products/1")
-                        .accept(MediaType.APPLICATION_JSON_UTF8)
-        )
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("쥐돌이")));
+    @Nested
+    @DisplayName("GET /products/{id} 는")
+    class Describe_detail {
+
+        @Nested
+        @DisplayName("만약 존재하는 productId로 요청이 들어오면")
+        class Context_with_existed_productId {
+
+            @BeforeEach
+            void prepareProduct() {
+                given(productService.getProduct(EXISTED_ID)).willReturn(product);
+            }
+
+            @Test
+            @DisplayName("HttpStatus 200 OK를 응답한다")
+            void it_returns_ok() throws Exception {
+                mockMvc.perform(get("/products/" + EXISTED_ID)
+                               .accept(MediaType.APPLICATION_JSON_UTF8))
+                       .andExpect(status().isOk())
+                       .andExpect(content().string(containsString(PRODUCT_NAME)));
+
+                verify(productService).getProduct(EXISTED_ID);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않은 productId로 요청이 들어오면")
+        class Context_with_not_existed_productId {
+
+            @BeforeEach
+            void prepareProduct() {
+                given(productService.getProduct(NOT_EXISTED_ID)).willThrow(new ProductNotFoundException(NOT_EXISTED_ID));
+            }
+
+            @Test
+            @DisplayName("HttpStatus 404 Not Found를 응답한다")
+            void it_returns_not_found() throws Exception {
+                mockMvc.perform(get("/products/" + NOT_EXISTED_ID))
+                       .andExpect(status().isNotFound());
+
+                verify(productService).getProduct(NOT_EXISTED_ID);
+            }
+        }
     }
 
-    @Test
-    void detailWithNotExistedProduct() throws Exception {
-        mockMvc.perform(get("/products/1000"))
-                .andExpect(status().isNotFound());
+    @Nested
+    @DisplayName("POST /products 는")
+    class Describe_create {
+
+        @Nested
+        @DisplayName("Jwt 토큰이 없거나 유효하지 않은 요청이 들어오면")
+        class Context_with_not_existed_or_invalid_jwt_token {
+
+            @Test
+            @DisplayName("HttpStatus 400 Bad Request를 응답한다")
+            void it_returns_bad_request() throws Exception {
+                String content = objectMapper.writeValueAsString(ProductData.builder()
+                                                                            .name("")
+                                                                            .maker("")
+                                                                            .price(0)
+                                                                            .build());
+
+                mockMvc.perform(post("/products")
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isBadRequest());
+
+                mockMvc.perform(post("/products")
+                               .header("Authorization", BEARER_TOKEN)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isBadRequest());
+            }
+        }
+
+        @Nested
+        @DisplayName("Jwt 토큰이 유효하고 프로덕트 생성 요청이 들어오면")
+        class Context_with_valid_jwt_token_and_product_data {
+
+            @BeforeEach
+            void prepareProduct() {
+                given(productService.createProduct(any(ProductData.class))).willReturn(product);
+            }
+
+            @Test
+            @DisplayName("HttpStatus 201 Created를 응답한다")
+            void it_returns_created() throws Exception {
+                String content = objectMapper.writeValueAsString(ProductData.builder()
+                                                                            .name(PRODUCT_NAME)
+                                                                            .maker(PRODUCT_MAKER)
+                                                                            .price(PRODUCT_PRICE)
+                                                                            .build());
+
+                mockMvc.perform(post("/products")
+                               .header("Authorization", BEARER_TOKEN)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isCreated())
+                       .andExpect(content().string(containsString(PRODUCT_NAME)));
+
+                verify(productService).createProduct(any(ProductData.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("Jwt 토큰이 유효하고 프로덕트 정보가 유효하지 않은 요청이 들어오면")
+        class Context_with_valid_jwt_token_and_invalid_product_data {
+
+            @Test
+            @DisplayName("HttpStatus 400 Bad Request를 응답한다")
+            void it_returns_bad_request() throws Exception {
+                String content = objectMapper.writeValueAsString(ProductData.builder()
+                                                                            .name("")
+                                                                            .maker("")
+                                                                            .price(0)
+                                                                            .build());
+
+                mockMvc.perform(post("/products")
+                               .header("Authorization", BEARER_TOKEN)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isBadRequest());
+            }
+        }
     }
 
-    @Test
-    void createWithValidAttributes() throws Exception {
-        mockMvc.perform(
-                post("/products")
-                        .accept(MediaType.APPLICATION_JSON_UTF8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"쥐돌이\",\"maker\":\"냥이월드\"," +
-                                "\"price\":5000}")
-        )
-                .andExpect(status().isCreated())
-                .andExpect(content().string(containsString("쥐돌이")));
+    @Nested
+    @DisplayName("PATCH /products/{id} 는")
+    class Describe_update {
 
-        verify(productService).createProduct(any(ProductData.class));
+        @Nested
+        @DisplayName("Jwt 토큰이 없거나 유효하지 않은 요청이 들어오면")
+        class Context_with_not_existed_or_invalid_jwt_token {
+
+            @Test
+            @DisplayName("HttpStatus 400 Bad Request를 응답한다")
+            void it_returns_bad_request() throws Exception {
+                String content = objectMapper.writeValueAsString(ProductData.builder()
+                                                                            .name("")
+                                                                            .maker("")
+                                                                            .price(0)
+                                                                            .build());
+
+                mockMvc.perform(patch("/products/" + EXISTED_ID)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isBadRequest());
+
+                mockMvc.perform(patch("/products/" + EXISTED_ID)
+                               .header("Authorization", BEARER_TOKEN)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isBadRequest());
+
+            }
+        }
+
+        @Nested
+        @DisplayName("Jwt 토큰이 유효하고 존재하는 productId와 정보로 요청이 들어오면")
+        class Context_with_valid_jwt_token_and_productId_and_productData {
+
+            @BeforeEach
+            void prepareProduct() {
+                given(productService.updateProduct(eq(EXISTED_ID), any(ProductData.class)))
+                        .will(invocation -> {
+                            Long id = invocation.getArgument(0);
+                            ProductData productData = invocation.getArgument(1);
+                            return Product.builder()
+                                    .id(id)
+                                    .name(productData.getName())
+                                    .maker(productData.getMaker())
+                                    .price(productData.getPrice())
+                                    .build();
+                        });
+            }
+
+            @Test
+            @DisplayName("HttpStatus 200 OK를 응답한다")
+            void it_returns_ok() throws Exception {
+                String content = objectMapper.writeValueAsString(ProductData.builder()
+                                                                            .name(UPDATE_PREFIX + PRODUCT_NAME)
+                                                                            .maker(PRODUCT_MAKER)
+                                                                            .price(PRODUCT_PRICE)
+                                                                            .build());
+
+                mockMvc.perform(patch("/products/" + EXISTED_ID)
+                               .header("Authorization", BEARER_TOKEN)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isOk())
+                       .andExpect(content().string(containsString(UPDATE_PREFIX + PRODUCT_NAME)));
+
+                verify(productService).updateProduct(eq(EXISTED_ID), any(ProductData.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("Jwt 토큰이 유효하고 존재하지 않은 productId로 요청이 들어오면")
+        class Context_with_valid_jwt_token_and_not_existed_productId {
+
+            @BeforeEach
+            void prepare() {
+                given(productService.updateProduct(eq(NOT_EXISTED_ID), any(ProductData.class))).willThrow(new ProductNotFoundException(NOT_EXISTED_ID));
+            }
+
+            @Test
+            @DisplayName("HttpStatus 404 Not Found를 응답한다")
+            void it_returns_not_found() throws Exception {
+                String content = objectMapper.writeValueAsString(ProductData.builder()
+                                                                            .name(UPDATE_PREFIX + PRODUCT_NAME)
+                                                                            .maker(PRODUCT_MAKER)
+                                                                            .price(PRODUCT_PRICE)
+                                                                            .build());
+
+                mockMvc.perform(patch("/products/" + NOT_EXISTED_ID)
+                               .header("Authorization", BEARER_TOKEN)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isNotFound());
+
+                verify(productService).updateProduct(eq(NOT_EXISTED_ID), any(ProductData.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("Jwt 토큰과 productId가 존재하고 프로덕트 정보가 유효하지 않은 요청이 들어오면")
+        class Context_with_valid_jwt_token_and_productId_and_invalid_productData {
+
+            @Test
+            @DisplayName("HttpStatus 400 Bad Request를 응답한다")
+            void it_returns_bad_request() throws Exception {
+                String content = objectMapper.writeValueAsString(ProductData.builder()
+                                                                            .name("")
+                                                                            .maker("")
+                                                                            .price(0)
+                                                                            .build());
+
+                mockMvc.perform(patch("/products/" + EXISTED_ID)
+                               .accept(MediaType.APPLICATION_JSON_UTF8)
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isBadRequest());
+            }
+        }
     }
 
-    @Test
-    void createWithInvalidAttributes() throws Exception {
-        mockMvc.perform(
-                post("/products")
-                        .accept(MediaType.APPLICATION_JSON_UTF8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"\",\"maker\":\"\"," +
-                                "\"price\":0}")
-        )
-                .andExpect(status().isBadRequest());
-    }
+    @Nested
+    @DisplayName("DELETE /products/{id} 는")
+    class Describe_destroy {
 
-    @Test
-    void updateWithExistedProduct() throws Exception {
-        mockMvc.perform(
-                patch("/products/1")
-                        .accept(MediaType.APPLICATION_JSON_UTF8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"쥐순이\",\"maker\":\"냥이월드\"," +
-                                "\"price\":5000}")
-        )
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("쥐순이")));
+        @Nested
+        @DisplayName("Jwt 토큰이 없거나 유효하지 않은 요청이 들어오면")
+        class Context_with_not_existed_or_invalid_jwt_token {
 
-        verify(productService).updateProduct(eq(1L), any(ProductData.class));
-    }
+            @BeforeEach
+            void prepare() {
+                given(authenticationService.parseToken(any(String.class))).willThrow(new InvalidTokenException(any(String.class)));
+            }
 
-    @Test
-    void updateWithNotExistedProduct() throws Exception {
-        mockMvc.perform(
-                patch("/products/1000")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"쥐순이\",\"maker\":\"냥이월드\"," +
-                                "\"price\":5000}")
-        )
-                .andExpect(status().isNotFound());
+            @Test
+            @DisplayName("HttpStatus 400 Bad Request를 응답한다")
+            void it_returns_bad_request() throws Exception {
+                mockMvc.perform(delete("/products/" + EXISTED_ID))
+                       .andExpect(status().isBadRequest());
 
-        verify(productService).updateProduct(eq(1000L), any(ProductData.class));
-    }
+                mockMvc.perform(delete("/products/" + EXISTED_ID)
+                               .header("Authorization", INVALID_BEARER_TOKEN))
+                       .andExpect(status().isBadRequest());
+            }
+        }
 
-    @Test
-    void updateWithInvalidAttributes() throws Exception {
-        mockMvc.perform(
-                patch("/products/1")
-                        .accept(MediaType.APPLICATION_JSON_UTF8)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"name\":\"\",\"maker\":\"\"," +
-                                "\"price\":0}")
-        )
-                .andExpect(status().isBadRequest());
-    }
+        @Nested
+        @DisplayName("Jwt 토큰이 유효하고 존재하는 productId로 요청이 들어오면")
+        class Context_with_valid_jwt_token_and_product_id {
 
-    @Test
-    void destroyWithExistedProduct() throws Exception {
-        mockMvc.perform(
-                delete("/products/1")
-        )
-                .andExpect(status().isNoContent());
+            @BeforeEach
+            void prepare() {
+                given(productService.deleteProduct(EXISTED_ID)).willReturn(product);
+            }
 
-        verify(productService).deleteProduct(1L);
-    }
+            @Test
+            @DisplayName("HttpStatus 204 No Content를 응답한다")
+            void it_returns_no_content() throws Exception {
+                mockMvc.perform(delete("/products/" + EXISTED_ID)
+                               .header("Authorization", BEARER_TOKEN))
+                       .andExpect(status().isNoContent());
 
-    @Test
-    void destroyWithNotExistedProduct() throws Exception {
-        mockMvc.perform(
-                delete("/products/1000")
-        )
-                .andExpect(status().isNotFound());
+                verify(productService).deleteProduct(EXISTED_ID);
+            }
+        }
 
-        verify(productService).deleteProduct(1000L);
+        @Nested
+        @DisplayName("Jwt 토큰이 유효하고 존재하지 않은 productId로 요청이 들어오면")
+        class Context_with_valid_jwt_token_and_not_existed_product_id {
+
+            @BeforeEach
+            void prepare() {
+                given(productService.deleteProduct(NOT_EXISTED_ID)).willThrow(new ProductNotFoundException(NOT_EXISTED_ID));
+            }
+
+            @Test
+            @DisplayName("HttpStatus 404 Not Found를 응답한다")
+            void it_returns_not_found() throws Exception {
+                mockMvc.perform(delete("/products/" + NOT_EXISTED_ID)
+                               .header("Authorization", BEARER_TOKEN))
+                       .andExpect(status().isNotFound());
+
+                verify(productService).deleteProduct(NOT_EXISTED_ID);
+            }
+        }
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/ProductControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/ProductControllerTest.java
@@ -12,23 +12,22 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
+import java.util.Arrays;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProductController.class)
 class ProductControllerTest {
-    private static final String VALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9." +
-            "eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
-    private static final String INVALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9." +
-            "eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaD0";
 
     @Autowired
     private MockMvc mockMvc;
@@ -44,7 +43,7 @@ class ProductControllerTest {
                 .maker("냥이월드")
                 .price(5000)
                 .build();
-        given(productService.getProducts()).willReturn(List.of(product));
+        given(productService.getProducts()).willReturn(Arrays.asList(product));
 
         given(productService.getProduct(1L)).willReturn(product);
 
@@ -84,7 +83,7 @@ class ProductControllerTest {
     }
 
     @Test
-    void deatilWithExsitedProduct() throws Exception {
+    void detailWithExistedProduct() throws Exception {
         mockMvc.perform(
                 get("/products/1")
                         .accept(MediaType.APPLICATION_JSON_UTF8)
@@ -94,7 +93,7 @@ class ProductControllerTest {
     }
 
     @Test
-    void deatilWithNotExsitedProduct() throws Exception {
+    void detailWithNotExistedProduct() throws Exception {
         mockMvc.perform(get("/products/1000"))
                 .andExpect(status().isNotFound());
     }

--- a/app/src/test/java/com/codesoom/assignment/controllers/SessionControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/SessionControllerTest.java
@@ -1,0 +1,134 @@
+package com.codesoom.assignment.controllers;
+
+import com.codesoom.assignment.application.AuthenticationService;
+import com.codesoom.assignment.dto.UserLoginData;
+import com.codesoom.assignment.errors.PasswordNotCorrectException;
+import com.codesoom.assignment.errors.UserNotFoundException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SessionController.class)
+class SessionControllerTest {
+
+    private static final String EXISTED_EMAIL = "example@login.com";
+    private static final String NOT_EXISTED_EMAIL = "not-existed@login.com";
+    private static final String CORRECT_PASSWORD = "password";
+    private static final String INCORRECT_PASSWORD = "incorrect";
+    private static final String VALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJleGFtcGxlQ" +
+                                              "GxvZ2luLmNvbSJ9.VC6A_h3VehY_zvmxNGtgdwCc6zeFRBcdKSkj2rNB93Y";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthenticationService authenticationService;
+
+    private UserLoginData userLoginData;
+
+    @Nested
+    @DisplayName("POST /session 은")
+    class Describe_login {
+
+        @Nested
+        @DisplayName("로그인 요청이 들어오면")
+        class Context_with_valid_userLoginData {
+
+            @BeforeEach
+            void prepareUserLoginData() {
+                userLoginData = UserLoginData.builder()
+                                             .email(EXISTED_EMAIL)
+                                             .password(CORRECT_PASSWORD)
+                                             .build();
+
+                given(authenticationService.login(any(UserLoginData.class))).willReturn(VALID_TOKEN);
+            }
+
+            @Test
+            @DisplayName("HttpStatus 201 Created 를 응답한다")
+            void it_returns_httpStatus_created() throws Exception {
+                String content = objectMapper.writeValueAsString(userLoginData);
+                mockMvc.perform(post("/session")
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isCreated())
+                       .andExpect(content().string(containsString(VALID_TOKEN)));
+
+                verify(authenticationService, atLeastOnce()).login(any(UserLoginData.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않은 Email로 요청이 들어오면")
+        class Context_with_not_existed_email_in_userLoginData {
+
+            @BeforeEach
+            void prepareNotExistedEmail() {
+                userLoginData = UserLoginData.builder()
+                                             .email(NOT_EXISTED_EMAIL)
+                                             .password(CORRECT_PASSWORD)
+                                             .build();
+
+                given(authenticationService.login(any(UserLoginData.class))).willThrow(new UserNotFoundException(NOT_EXISTED_EMAIL));
+            }
+
+            @Test
+            @DisplayName("HttpStatus 404 Not Found 를 응답한다")
+            void it_returns_httpStatus_not_found() throws Exception {
+                String content = objectMapper.writeValueAsString(userLoginData);
+                mockMvc.perform(post("/session")
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isNotFound());
+
+                verify(authenticationService, atLeastOnce()).login(any(UserLoginData.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 틀린 Password로 요청이 들어오면")
+        class Context_with_incorrect_password_in_userLoginData {
+
+            @BeforeEach
+            void prepareIncorrectPassword() {
+                userLoginData = UserLoginData.builder()
+                                             .email(EXISTED_EMAIL)
+                                             .password(INCORRECT_PASSWORD)
+                                             .build();
+
+                given(authenticationService.login(any(UserLoginData.class))).willThrow(new PasswordNotCorrectException());
+            }
+
+            @Test
+            @DisplayName("HttpStatus 401 Unauthorized 를 응답한다")
+            void it_returns_httpStatus_unauthorized() throws Exception {
+                String content = objectMapper.writeValueAsString(userLoginData);
+                mockMvc.perform(post("/session")
+                               .contentType(MediaType.APPLICATION_JSON)
+                               .content(content))
+                       .andExpect(status().isUnauthorized());
+
+                verify(authenticationService, atLeastOnce()).login(any(UserLoginData.class));
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/controllers/SessionControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/SessionControllerTest.java
@@ -50,7 +50,7 @@ class SessionControllerTest {
     class Describe_login {
 
         @Nested
-        @DisplayName("로그인 요청이 들어오면")
+        @DisplayName("주어진 사용자 정보를 사용해 로그인에 성공하면")
         class Context_with_valid_userLoginData {
 
             @BeforeEach
@@ -78,7 +78,7 @@ class SessionControllerTest {
         }
 
         @Nested
-        @DisplayName("만약 존재하지 않은 Email로 요청이 들어오면")
+        @DisplayName("이메일이 존재하지 않아 로그인에 실패하면")
         class Context_with_not_existed_email_in_userLoginData {
 
             @BeforeEach
@@ -105,7 +105,7 @@ class SessionControllerTest {
         }
 
         @Nested
-        @DisplayName("만약 틀린 Password로 요청이 들어오면")
+        @DisplayName("패스워드가 틀려 로그인에 실패하면")
         class Context_with_incorrect_password_in_userLoginData {
 
             @BeforeEach
@@ -119,13 +119,13 @@ class SessionControllerTest {
             }
 
             @Test
-            @DisplayName("HttpStatus 401 Unauthorized 를 응답한다")
+            @DisplayName("HttpStatus 400 BadRequest 를 응답한다")
             void it_returns_httpStatus_unauthorized() throws Exception {
                 String content = objectMapper.writeValueAsString(userLoginData);
                 mockMvc.perform(post("/session")
                                .contentType(MediaType.APPLICATION_JSON)
                                .content(content))
-                       .andExpect(status().isUnauthorized());
+                       .andExpect(status().isBadRequest());
 
                 verify(authenticationService, atLeastOnce()).login(any(UserLoginData.class));
             }

--- a/app/src/test/java/com/codesoom/assignment/utils/JwtUtilTest.java
+++ b/app/src/test/java/com/codesoom/assignment/utils/JwtUtilTest.java
@@ -1,0 +1,98 @@
+package com.codesoom.assignment.utils;
+
+import com.codesoom.assignment.errors.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtUtilTest {
+
+    private static final String SECRET = "12345678901234567890123456789012";
+    private static final String USER_EMAIL = "userEmail";
+    private static final String VALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJleGFtcGxlQGxvZ2l" +
+                                              "uLmNvbSJ9.VC6A_h3VehY_zvmxNGtgdwCc6zeFRBcdKSkj2rNB93Y";
+    private static final String INVALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyRW1haWwiOiJleGFtcGxlQGxvZ2l" +
+                                                "uLmNvbSJ9.VC6A_h3VehY_zvmxNGtgdwCc6zeFRBcdKSkj2rNB9aa";
+    private static final String EXISTED_EMAIL = "example@login.com";
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        jwtUtil = new JwtUtil(SECRET);
+    }
+
+
+    @Nested
+    @DisplayName("encode 메소드는")
+    class Describe_encode {
+
+        @Nested
+        @DisplayName("userEmail이 주어지면")
+        class Context_with_userEmail {
+
+            @Test
+            @DisplayName("토큰을 리턴한다")
+            void it_returns_token() {
+                String token = jwtUtil.encode(EXISTED_EMAIL);
+                assertThat(token).isEqualTo(VALID_TOKEN);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("decode 메소드는")
+    class Describe_decode {
+
+        @Nested
+        @DisplayName("유효한 token이 주어지면")
+        class Context_with_valid_token {
+
+            @Test
+            @DisplayName("클레임을 리턴한다")
+            void it_returns_claims() {
+                Claims claims = jwtUtil.decode(VALID_TOKEN);
+                assertThat(claims.get(USER_EMAIL)).isEqualTo(EXISTED_EMAIL);
+            }
+        }
+
+        @Nested
+        @DisplayName("유효하지 않은 token이 주어지면")
+        class Context_with_invalid_token {
+
+            @Test
+            @DisplayName("InvalidTokenException 예외를 리턴한다")
+            void it_returns_invalidTokenException() {
+                assertThatThrownBy(() -> jwtUtil.decode(INVALID_TOKEN)).isInstanceOf(InvalidTokenException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("Null인 token이 주어지면")
+        class Context_with_null_token {
+
+            @Test
+            @DisplayName("InvalidTokenException 예외를 리턴한다")
+            void it_returns_invalidTokenException() {
+                assertThatThrownBy(() -> jwtUtil.decode(null)).isInstanceOf(InvalidTokenException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("비어있는 token이 주어지면")
+        class Context_with_empty_or_blank_token {
+
+            @Test
+            @DisplayName("InvalidTokenException 예외를 리턴한다")
+            void it_returns_invalidTokenException() {
+                assertThatThrownBy(() -> jwtUtil.decode("")).isInstanceOf(InvalidTokenException.class);
+                assertThatThrownBy(() -> jwtUtil.decode("  ")).isInstanceOf(InvalidTokenException.class);
+            }
+        }
+    }
+}

--- a/tests/__tests__/session.spec.js
+++ b/tests/__tests__/session.spec.js
@@ -48,7 +48,7 @@ describe('Session', () => {
           email: 'notexists@email.com',
           password: 'wrong password',
         })
-          .expect('status', 400);
+          .expect('status', 404);
       });
     });
   });


### PR DESCRIPTION
안녕하세요 6주차 과제 제출합니다. 잘부탁드립니다 이번주도!
현재 로그인 기능구현만 완료했습니다!

## 과제목표
### 로그인이 필요없는 API
- [x] 로그인 하기 - `POST /session`
- [x] 회원 생성하기 - `POST /users`
- [x] 회원 수정하기 - `POST /users/{id}`
- [x] 회원 삭제하기 - `DELETE /users/{id}`
- [x] 고양이 장난감 목록 얻기 - `GET /products`
- [x] 고양이 장난감 상세 조회하기 - `GET /products/{id}`

### 로그인이 필요한 API
- [x] 고양이 장난감 등록하기 - POST /products
- [x] 고양이 장난감 수정하기 - PATCH /products/{id}
- [x] 고양이 장난감 삭제하기 - DELETE /products/{id}

<br>

- [x] SessionController MockMVC 테스트
- [x] SessionController 모델 테스트
- [x] AuthenticationService 테스트
- [x] JwtUtil 테스트


<br>

- [x] 테스트 커버리지 100%를 달성해야 합니다.
- [ ] 모든 API 테스트를 통과해야 합니다.
- [ ] 모든 E2E 테스트를 통과해야 합니다.