### PR TITLE
Edit response status to 404

### DIFF
--- a/tests/__tests__/session.spec.js
+++ b/tests/__tests__/session.spec.js
@@ -48,7 +48,7 @@ describe('Session', () => {
           email: 'notexists@email.com',
           password: 'wrong password',
         })
-          .expect('status', 400);
+          .expect('status', 404);
       });
     });
   });


### PR DESCRIPTION
session API test의 존재하지 않는 유저에 대한 테스트 케이스의 
response의 status를 400에서 404로 수정하였습니다.